### PR TITLE
Improve types to handle Dune API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ import { Dune } from 'dune-api-client'
 const dune = new Dune('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
 
 const execute = await dune.execute(3224138)
-const status = await dune.status(execute.execution_id)
-const res = await dune.results(execute.execution_id)
+const status = await dune.status(execute.data.execution_id)
+const res = await dune.results(execute.data.execution_id)
 ```
 
 The second approach is to read the latest results from a query, regardless of how it was executed (including on the Dune website).
@@ -38,7 +38,7 @@ type DuneData = {
 }
 
 const res = await dune.results<DuneData>(3224138)
-// res.result.rows will be of type DuneData[]
+// res.data.result.rows will be of type DuneData[]
 ```
 
 The `dune.execute` and `dune.results` methods support query params (text, number, and date).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dune-api-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Greg Skriloff",
   "keywords": [
     "Dune Analytics",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   ExecutionResult,
   CancelQuery,
   ExecuteQueryOptions,
+  DataOrError,
 } from './types'
 
 export class Dune {
@@ -27,7 +28,7 @@ export class Dune {
     method: 'GET' | 'POST',
     endpoint: string,
     body?: { query_parameters?: ExecuteQueryOptions['params'] }
-  ): Promise<T> {
+  ): Promise<DataOrError<T>> {
     const res = await fetch(endpoint, {
       method,
       headers: {
@@ -36,8 +37,13 @@ export class Dune {
       body: method === 'POST' ? JSON.stringify(body) : undefined,
     })
 
-    const json = (await res.json()) as T
-    return json
+    const json = await res.json()
+
+    if (json.error) {
+      return { error: json.error }
+    }
+
+    return { data: json as T }
   }
 
   /**
@@ -48,7 +54,7 @@ export class Dune {
   async execute(
     query_id: number,
     options?: ExecuteQueryOptions
-  ): Promise<ExecuteQuery> {
+  ): Promise<DataOrError<ExecuteQuery>> {
     const endpoint = this.BASE_URL + '/query/' + query_id + '/execute'
     const body = { query_parameters: options?.params }
     return await this.fetchDune<ExecuteQuery>('POST', endpoint, body)
@@ -59,7 +65,7 @@ export class Dune {
    * @param execution_id Dune execution id
    * @returns Success of cancellation
    */
-  async cancel(execution_id: string): Promise<CancelQuery> {
+  async cancel(execution_id: string): Promise<DataOrError<CancelQuery>> {
     const endpoint = this.BASE_URL + '/execution/' + execution_id + '/cancel'
     return await this.fetchDune<CancelQuery>('POST', endpoint)
   }
@@ -69,7 +75,7 @@ export class Dune {
    * @param execution_id Dune execution id
    * @returns Status of execution
    */
-  async status(execution_id: string): Promise<ExecutionStatus> {
+  async status(execution_id: string): Promise<DataOrError<ExecutionStatus>> {
     const endpoint = this.BASE_URL + '/execution/' + execution_id + '/status'
     return await this.fetchDune<ExecutionStatus>('GET', endpoint)
   }
@@ -82,7 +88,7 @@ export class Dune {
   async results<T>(
     exec_or_query_id: string | number,
     options?: ExecuteQueryOptions
-  ): Promise<ExecutionResult<T>> {
+  ): Promise<DataOrError<ExecutionResult<T>>> {
     const isIdNumber = /^\d+$/.test(exec_or_query_id.toString())
     let endpoint: string
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export class Dune {
     const json = await res.json()
 
     if (json.error) {
-      return { error: json.error }
+      return json as { error: string }
     }
 
     return { data: json as T }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,3 @@
-type Prettify<T> = {
-  [K in keyof T]: T[K]
-} & {}
-
 type QueryState =
   | 'QUERY_STATE_PENDING'
   | 'QUERY_STATE_EXECUTING'
@@ -63,7 +59,6 @@ export interface ExecutionResult<T> {
   result?: ExecutionResultData<T>
 }
 
-export type DataOrError<T> = Prettify<{
-  data?: Prettify<T>
-  error?: string
-}>
+export type DataOrError<T> =
+  | { data: T; error?: undefined }
+  | { data?: undefined; error: string }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,8 +8,11 @@ type QueryState =
 
 interface ResultMetadata {
   column_names: string[]
+  column_types: string[]
+  row_count: number
   result_set_bytes: number
   total_row_count: number
+  total_result_set_bytes: number
   datapoint_count: number
   pending_time_millis: number
   execution_time_millis: number
@@ -36,6 +39,7 @@ export interface CancelQuery {
 export interface ExecutionStatus {
   execution_id: string
   query_id: number
+  is_execution_finished: boolean
   state: QueryState
   submitted_at: string
 
@@ -49,6 +53,7 @@ export interface ExecutionStatus {
 export interface ExecutionResult<T> {
   execution_id: string
   query_id: number
+  is_execution_finished: boolean
   state: QueryState
   submitted_at: string
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,7 @@
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
 type QueryState =
   | 'QUERY_STATE_PENDING'
   | 'QUERY_STATE_EXECUTING'
@@ -59,7 +63,7 @@ export interface ExecutionResult<T> {
   result?: ExecutionResultData<T>
 }
 
-export interface DataOrError<T> {
-  data?: T
+export type DataOrError<T> = Prettify<{
+  data?: Prettify<T>
   error?: string
-}
+}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,3 +58,8 @@ export interface ExecutionResult<T> {
   execution_ended_at?: string
   result?: ExecutionResultData<T>
 }
+
+export interface DataOrError<T> {
+  data?: T
+  error?: string
+}


### PR DESCRIPTION
All functions now have the following return type:

```ts
interface DataOrError<T> {
  data?: T
  error?: string
}
```

This is a breaking change. For example, what was previously `res.result.rows` is now `res.data.result.rows`. Developers should check if `res.data` exists before assuming the response is safe.